### PR TITLE
Fix Windows and latest Anki version compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-An Anki plugin that imports review history for words studied in [JPDB](https://jpdb.io).
+An Anki plugin that imports review history for words studied in [JPDB](https://jpdb.io). Currently working as of Anki 2.60.0.
 
 This plugin imports the following information:
 * Japanese spelling (e.g. 言葉)

--- a/README.md
+++ b/README.md
@@ -30,6 +30,19 @@ make the resulting cards richer with little effort.
 3. After installing this add-on, in Anki, go to "Tools" => "Import from JPDB"
 4. Follow the instructions in the setup window.
 
+## Building
+To build the package, run `python3 build.py` in the command line which will generate the add-on file `jpdb_anki_import.ankiaddon`.
+
+### Testing
+To test the file in Anki, perform the following steps:
+
+1. Open Anki and click on "Tools" in the top menu bar.
+2. Select "Add-ons" from the dropdown menu.
+3. Click on "Install from file..."
+4. Navigate to the directory where the jpdb_anki_import.ankiaddon file was generated, and select it.
+5. Click "Open" to install the addon.
+6. Restart Anki if prompted to do so.
+
 ## Recommended Additional Plugins
 
 The following other Anki plugins can help flesh out cards created after the import to add translation and more detail:

--- a/build.py
+++ b/build.py
@@ -1,16 +1,20 @@
 import os
 import zipfile
 
-addon_name = "jpdb_anki_import.ankiaddon"
-source_dir = "jpdb_anki_import"
+addon_name = 'jpdb_anki_import.ankiaddon'
+source_dir = 'jpdb_anki_import'
 
 # Create a zip file containing all the .py files in the source directory
-with zipfile.ZipFile(addon_name, "w") as addon_zip:
+with zipfile.ZipFile(addon_name, 'w') as addon_zip:
+    addon_zip.write('manifest.json')
     for root, dirs, files in os.walk(source_dir):
         for file in files:
-            if file.endswith(".py"):
+            if file.endswith('.py'):
                 file_path = os.path.join(root, file)
-                arcname = os.path.relpath(file_path, source_dir)
-                addon_zip.write(file_path, arcname)
+                # ensure file is added to root of zip file
+                arc_file_name = os.path.basename(file_path)
+                addon_zip.write(file_path, arc_file_name)
 
-print(f"Addon built successfully")
+addon_path = os.path.abspath(addon_name);
+
+print(f'Add-on built successfully at {addon_path}')

--- a/build.py
+++ b/build.py
@@ -1,0 +1,16 @@
+import os
+import zipfile
+
+addon_name = "jpdb_anki_import.ankiaddon"
+source_dir = "jpdb_anki_import"
+
+# Create a zip file containing all the .py files in the source directory
+with zipfile.ZipFile(addon_name, "w") as addon_zip:
+    for root, dirs, files in os.walk(source_dir):
+        for file in files:
+            if file.endswith(".py"):
+                file_path = os.path.join(root, file)
+                arcname = os.path.relpath(file_path, source_dir)
+                addon_zip.write(file_path, arcname)
+
+print(f"Addon built successfully")

--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,0 @@
-#!/bin/sh
-
-cd jpdb_anki_import || exit 1
-zip -r ../jpdb_anki_import.ankiaddon ./*.py

--- a/jpdb_anki_import/config.py
+++ b/jpdb_anki_import/config.py
@@ -81,20 +81,20 @@ class ConfigGUI(aqt.qt.QDialog):
 
     def _setup_review_file(self):
         def select_file():
-            path, ok = aqt.qt.QFileDialog.getOpenFileUrl(
+            # we ignore response code because path is None if user cancels
+            path, _ = aqt.qt.QFileDialog.getOpenFileName(
                 self,
                 "JPDB Vocabulary Export",
-                aqt.qt.QUrl(str(pathlib.Path.home())),
+                str(pathlib.Path.home()),
                 "*.json"
             )
-            if not ok:
+
+            if not path:
                 return
 
-            if path.isValid():
-                path = path.path()
-                self._selected_file_label.setText(path)
-                self._config.review_file = path
-                self._set_ok_enabled(True)
+            self._selected_file_label.setText(path)
+            self._config.review_file = path
+            self._set_ok_enabled(True)
 
         button = aqt.qt.QPushButton("Open")
         button.clicked.connect(select_file)

--- a/jpdb_anki_import/importer.py
+++ b/jpdb_anki_import/importer.py
@@ -45,7 +45,7 @@ class JPDBImporter:
 
     def card_state_current_next(self, card: Card, rating: str) -> (CardAnswer, CardAnswer):
         # The following code is taken directly from the Anki v3 scheduler
-        states = self.anki.col._backend.get_next_card_states(card.id)
+        states = self.anki.col.backend.get_scheduling_states(card.id)
         if rating == CardAnswer.AGAIN:
             new_state = states.again
         elif rating == CardAnswer.HARD:

--- a/jpdb_anki_import/importer.py
+++ b/jpdb_anki_import/importer.py
@@ -45,7 +45,11 @@ class JPDBImporter:
 
     def card_state_current_next(self, card: Card, rating: str) -> (CardAnswer, CardAnswer):
         # The following code is taken directly from the Anki v3 scheduler
-        states = self.anki.col.backend.get_scheduling_states(card.id)
+        if hasattr(self.anki.col.backend, 'get_scheduling_states'):
+            states = self.anki.col.backend.get_scheduling_states(card.id)
+        else:
+            # Anki < 2.1.60
+            states = self.anki.col.backend.get_next_card_states(card.id)
         if rating == CardAnswer.AGAIN:
             new_state = states.again
         elif rating == CardAnswer.HARD:

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,8 @@
+{
+    "name": "JPDB Anki Importer",
+    "description": "An Anki plugin that imports review history for words studied in JPDB.",
+    "package": "jpdb_anki_import",
+    "version": "1.0.1",
+    "min_point_version": 60,
+    "license": ""
+}

--- a/manifest.json
+++ b/manifest.json
@@ -3,6 +3,6 @@
     "description": "An Anki plugin that imports review history for words studied in JPDB.",
     "package": "jpdb_anki_import",
     "version": "1.0.1",
-    "min_point_version": 60,
+    "min_point_version": 51,
     "license": ""
 }


### PR DESCRIPTION
The path when importing the file on Windows is incorrect (adds leading '/') which causes the error noted on the [addon page](https://ankiweb.net/shared/info/541896873) in a review on 12/13/2022.

Additionally, the build script only works on Unix-like systems which this PR replaces with a python file that works on Unix-like and Windows systems. It also includes a manifest which was previously not included by the previous build process. Note that I made the version 1.0.1 arbitrarily which can be changed (I don't believe there previously was a version).

For supporting the newest Anki version, a function was changed at some point before 2.1.60 (not sure in which version it was changed) which caused errors when importing JPDB cards which was also fixed.

If there are any issues or anything you'd like for me to change (including splitting this up into multiple PR's), please let me know.